### PR TITLE
Make IR integration only on client

### DIFF
--- a/init.coffee
+++ b/init.coffee
@@ -85,3 +85,4 @@ Meteor.startup ->
       log "Tracking #{eventName} for #{Meteor.userId()}"
       g.analytics.track eventName
     @next()
+    ,{where : 'client'}


### PR DESCRIPTION
This is a pb if you have serverside routes because onRun runs for those as well and  Meteor.userId() throws an error in that context.
